### PR TITLE
feat: worktree間を即座に遷移できる wt コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ waseda-syllabus-mcp/
 ### Working with Worktrees
 
 See `scripts/worktree-helper.sh` for common operations.
+
+### Worktree間の素早い移動 (`wt`)
+
+`scripts/wt.sh` を source すると `wt` コマンドが使えるようになる。
+
+```bash
+# ~/.bashrc または ~/.zshrc に追記
+source /home/tksch/waseda-syllabus-mcp/main/scripts/wt.sh
+```
+
+使い方:
+
+```bash
+wt main      # main worktreeへ移動
+wt 13        # WMCP-13-... のworktreeへ移動
+wt WMCP-13   # 同上
+```

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# wt: worktree間のディレクトリ遷移コマンド
+#
+# 使い方:
+#   wt main          → main worktreeへ移動
+#   wt <番号>        → WMCP-<番号>-... のworktreeへ移動
+#   wt WMCP-<番号>   → WMCP-<番号>-... のworktreeへ移動
+#
+# セットアップ:
+#   以下を ~/.bashrc または ~/.zshrc に追記する:
+#   source /path/to/scripts/wt.sh
+#
+# このファイルはシェル関数として source して使う。
+# スクリプトとして直接実行しても cd は現在のシェルに反映されない。
+
+_wt_find_project_root() {
+  local dir
+  dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  if [[ -z "$dir" ]]; then
+    echo "Error: gitリポジトリが見つかりません" >&2
+    return 1
+  fi
+  # .bare の親ディレクトリがプロジェクトルート
+  dirname "$dir"
+}
+
+wt() {
+  local arg="${1:?使い方: wt <main|番号|WMCP-番号>}"
+  local project_root
+  project_root=$(_wt_find_project_root) || return 1
+
+  # main の場合
+  if [[ "$arg" == "main" ]]; then
+    cd "$project_root/main" || return 1
+    return 0
+  fi
+
+  # 番号または WMCP-番号 の場合
+  local issue_num
+  if [[ "$arg" =~ ^WMCP-([0-9]+)$ ]]; then
+    issue_num="${BASH_REMATCH[1]}"
+  elif [[ "$arg" =~ ^[0-9]+$ ]]; then
+    issue_num="$arg"
+  else
+    echo "Error: 引数は main, 番号, または WMCP-番号 の形式で指定してください" >&2
+    return 1
+  fi
+
+  local worktrees_dir="$project_root/worktrees"
+  local matches=()
+  while IFS= read -r -d '' dir; do
+    matches+=("$dir")
+  done < <(find "$worktrees_dir" -maxdepth 1 -type d -name "WMCP-${issue_num}-*" -print0 2>/dev/null)
+
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    echo "Error: WMCP-${issue_num} に対応するworktreeが見つかりません" >&2
+    echo "  worktrees/: $(ls "$worktrees_dir" 2>/dev/null)" >&2
+    return 1
+  fi
+
+  if [[ ${#matches[@]} -gt 1 ]]; then
+    echo "Error: 複数のworktreeがマッチしました:" >&2
+    for m in "${matches[@]}"; do
+      echo "  $(basename "$m")" >&2
+    done
+    return 1
+  fi
+
+  cd "${matches[0]}" || return 1
+}


### PR DESCRIPTION
## Summary

- `scripts/wt.sh` にシェル関数 `wt` を追加
- `wt main` で main worktree、`wt <番号>` または `wt WMCP-<番号>` で対応する worktree へ `cd` できる
- カレントシェルで動作させるため source して使う方式を採用
- README にセットアップ手順を追記

## Usage

```bash
# ~/.bashrc または ~/.zshrc に追記
source /home/tksch/waseda-syllabus-mcp/main/scripts/wt.sh

wt main    # main worktreeへ移動
wt 13      # WMCP-13-... のworktreeへ移動
```

## Related Issue

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)