### PR TITLE
Design Doc: Crawler Strategy

### DIFF
--- a/docs/design/crawler-design.md
+++ b/docs/design/crawler-design.md
@@ -3,19 +3,19 @@
 ## 概要
 
 早稲田大学シラバスサイト (`wsl.waseda.jp/syllabus/`) からシラバスデータを収集するクローラーの設計。
-学部ごとに異なるpKey構造に対応するため、**pKey生成方式**と**検索API方式**の2つの戦略を使い分ける。
+`nendo` パラメータのみで全学部・全学科のシラバスを一括取得する。
 
 ## 目標
 
 - **主要な目標**
-  - 基幹理工学部のシラバスをpKey生成方式で効率的に収集する
-  - 他学部のシラバスを検索API経由で収集する
+  - `JAA103.php?nendo={year}` から全シラバスのpKeyを収集する
+  - pKey一覧をもとに `JAA104.php` から詳細データを取得してDBに保存する
   - サイトに不必要な負荷をかけないレート制限を実装する
 
 - **非目標**
   - リアルタイムクローリング（定期バッチ実行を想定）
   - ログイン後のコンテンツ取得（公開シラバスのみ対象）
-  - 807,127件の全データを常時最新化（年度単位での更新を想定）
+  - 全年度データの常時最新化（年度単位での更新を想定）
 
 ## 背景
 
@@ -33,168 +33,96 @@ JAA104.php?pKey=XXXX  シラバス詳細
 pKeyが判明すれば直接アクセスが可能。検索結果ページのリンクはJavaScript動的生成のため、
 静的HTMLスクレイピングではpKeyを取得できない。
 
+`JAA103.php` のGETパラメータのうち `nendo` のみが有効に機能する。
+2026年度の全シラバスは約35,000件。
+
 ## 設計
 
 ### アーキテクチャ
 
 ```
-CrawlerOrchestrator
-    ├── KSRICrawler (基幹理工学部)
-    │   └── PKeyGenerator → httpx → SyllabusParser
-    └── GenericCrawler (他学部)
-        └── PlaywrightSearcher → pKey抽出 → httpx → SyllabusParser
-                    ↓
-              PostgreSQL (syllabuses テーブル)
+PlaywrightSearcher
+  └── JAA103.php?nendo={year} → ページネーション全走査 → pKey一覧
+          ↓
+      httpx (逐次, 1req/s)
+          ↓
+      JAA104.php?pKey=XXXX → SyllabusParser
+          ↓
+      PostgreSQL (syllabuses テーブル)
 ```
 
-### pKey構造（基幹理工学部）
+### クローリング戦略
 
-pKeyは**28文字固定**で前半16文字 + 後半12文字で構成される。
-
-```
-位置   文字数  内容              例
-1-2    2       年度下2桁         26      (2026年度)
-3-4    2       学科コード        03
-5-6    2       科目区分コード    01
-7-10   4       科目コード        2001    (学年+連番)
-11-12  2       クラスコード      01
-13-16  4       開講年度(4桁)     2026
-17-18  2       年度（繰り返し）  26
-19-20  2       学科（参照先）    03      (通常は前半と同じ)
-21-22  2       区分（参照先）    01
-23-26  4       科目（参照先）    2001
-27-28  2       年度（繰り返し）  26
-```
-
-#### 学科コード（基幹理工学部）
-
-| コード | 学科 |
-|--------|------|
-| `00` | 基幹共通科目 |
-| `01` | 数学科 |
-| `02` | 応用数理学科 |
-| `03` | 情報理工学科 |
-| `05` | 未確認（物理系の可能性） |
-| `07` | 情報通信学科 |
-
-#### 科目区分コード
-
-| コード | 区分 |
-|--------|------|
-| `01` | 専門必修 |
-| `02` | 選択必修 |
-| `03` | 専門選択 |
-| `04` | その他 |
-
-#### 科目コードの読み方
-
-```
-7-10の4文字: 先頭1桁が学年、残り3桁が連番
-  2xxx = 2年次科目
-  3xxx = 3年次科目
-  4xxx = 4年次科目
-```
-
-#### 後半部分（参照先）の扱い
-
-複数学科で同一内容を開講する場合、後半が前半と異なる値になる：
-
-```
-例：情報数学A（情報通信学科 dept=07）
-pKey前半: 26 07 02 2007 01 2026
-pKey後半: 26 03 03 2002 26
-          ↑ 情報理工学科(03)の科目2002を参照
-```
-
-この場合、後半はコンテンツの正規実体（マスター科目）を示す。
-pKey生成時は後半も前半と同じ値で試み、存在しない場合はスキップする。
-
-### pKey生成戦略（基幹理工学部）
+`JAA103.php?pLng=jp&nendo={year}` に対してPlaywrightでアクセスし、
+ページネーションを全走査してpKeyを収集する。
 
 ```python
-def generate_pkeys(year: int, dept_code: str) -> list[str]:
-    """基幹理工学部のpKey候補を総当たりで生成する"""
-    year_s = str(year)[-2:]  # 下2桁
-    year_full = str(year)
+async def fetch_all_pkeys(page: Page, nendo: str) -> list[str]:
+    url = f"https://www.wsl.waseda.jp/syllabus/JAA103.php?pLng=jp&nendo={nendo}"
+    await page.goto(url)
+    await page.wait_for_load_state("networkidle")
 
     pkeys = []
-    for cat in ["01", "02", "03", "04"]:
-        for grade in [2, 3, 4]:
-            for num in range(1, 100):  # 連番の上限は余裕を持たせる
-                code = f"{grade}{num:03d}"
-                for cls in ["01", "02", "03"]:  # クラスコード
-                    pkey = (
-                        f"{year_s}{dept_code}{cat}{code}{cls}{year_full}"
-                        f"{year_s}{dept_code}{cat}{code}{year_s}"
-                    )
-                    pkeys.append(pkey)
+    while True:
+        links = await page.query_selector_all("a[href*='JAA104.php']")
+        for link in links:
+            href = await link.get_attribute("href")
+            pkey = extract_pkey_from_href(href)
+            if pkey:
+                pkeys.append(pkey)
+
+        # 次ページへ（なければ終了）
+        next_btn = await page.query_selector("次ページのセレクタ")
+        if not next_btn:
+            break
+        await next_btn.click()
+        await page.wait_for_load_state("networkidle")
+
     return pkeys
 ```
-
-存在しないpKeyへのアクセスはエラーページが返るため、レスポンスの内容で判定してスキップする。
-
-### 検索API戦略（他学部）
-
-他学部はpKey構造が学部固有のため総当たりが困難。JAA103.phpのGETパラメータで絞り込み後、
-PlaywrightでDOM上のリンクからpKeyを抽出する。
 
 #### 動作確認済みパラメータ
 
 | パラメータ | 効果 | 例 |
 |-----------|------|----|
 | `pLng` | 言語切替 | `jp` |
-| `p_gakubu` | 学部で絞り込み | `51`（基幹理工） |
-| `nendo` | 年度で絞り込み | `2026` |
+| `nendo` | 年度で絞り込み ✅ | `2026` |
+| `p_gakubu` | 学部で絞り込み ✅ | `51`（基幹理工）|
 | `p_nendo` | 効かない | - |
 | `p_keyw` | 効かない（POSTのみ） | - |
-
-#### Playwright操作フロー
-
-```python
-async def fetch_pkeys_via_search(
-    page: Page, gakubu: str, nendo: str
-) -> list[str]:
-    url = (
-        "https://www.wsl.waseda.jp/syllabus/JAA103.php"
-        f"?pLng=jp&p_gakubu={gakubu}&nendo={nendo}"
-    )
-    await page.goto(url)
-    await page.wait_for_load_state("networkidle")
-
-    # リンクのhref属性からpKeyを抽出
-    links = await page.query_selector_all("a[href*='JAA104.php']")
-    pkeys = []
-    for link in links:
-        href = await link.get_attribute("href")
-        # href例: "javascript:showSyllabus('XXXX')" or "JAA104.php?pKey=XXXX"
-        pkey = extract_pkey_from_href(href)
-        if pkey:
-            pkeys.append(pkey)
-
-    # ページネーションがある場合は次ページへ
-    return pkeys
-```
 
 ### Playwright / httpx の使い分け
 
 | 用途 | ツール | 理由 |
 |------|--------|------|
+| 検索結果ページのpKey収集（JAA103.php） | `Playwright` | JavaScriptでリンク動的生成 |
 | シラバス詳細取得（JAA104.php） | `httpx` | JavaScript不要、静的HTML |
-| pKey既知のバッチ取得 | `httpx` | 高速・並列処理が容易 |
-| 検索結果ページのpKey収集 | `Playwright` | JavaScriptでリンク動的生成 |
-| ページネーション操作 | `Playwright` | DOM操作が必要 |
+
+### pKey構造（参考）
+
+pKeyは**28文字固定**。基幹理工学部は数字のみ、他学部は英数字混在のケースあり。
+
+```
+位置   文字数  内容
+1-2    2       年度下2桁
+3-4    2       学科コード
+5-6    2       科目区分コード
+7-10   4       科目コード（学年+連番）
+11-12  2       クラスコード
+13-16  4       開講年度（4桁）
+17-28  12      参照先情報（通常は前半の繰り返し）
+```
+
+pKeyはJAA103.phpから取得するため、構造の詳細知識はクローラーの動作に不要。
 
 ### HTMLパース戦略
-
-シラバス詳細ページ（JAA104.php）の構造：
 
 ```python
 from bs4 import BeautifulSoup
 
-def parse_syllabus(html: str, pkey: str) -> dict:
+def parse_syllabus(html: str, pkey: str) -> dict | None:
     soup = BeautifulSoup(html, "html.parser")
 
-    # エラーページの判定（シラバスが存在しない場合）
     if is_error_page(soup):
         return None
 
@@ -202,24 +130,17 @@ def parse_syllabus(html: str, pkey: str) -> dict:
         "pkey": pkey,
         "title": extract_title(soup),
         "instructor": extract_instructor(soup),
-        "semester": extract_semester(soup),   # Spring/Fall/Full-year
+        "semester": extract_semester(soup),
         "credits": extract_credits(soup),
         "department": extract_department(soup),
         "year": extract_year(soup),
         "description": extract_description(soup),
         "objectives": extract_objectives(soup),
-        "schedule": extract_schedule(soup),   # 週ごとの授業内容
+        "schedule": extract_schedule(soup),
         "evaluation": extract_evaluation(soup),
         "textbooks": extract_textbooks(soup),
-        "raw_html": html,                     # 生HTMLも保存（再パース用）
+        "raw_html": html,
     }
-
-def is_error_page(soup: BeautifulSoup) -> bool:
-    """存在しないpKeyへのアクセスを判定"""
-    # サイト固有のエラー文言で判定
-    error_markers = ["該当するシラバスはありません", "No syllabus found"]
-    text = soup.get_text()
-    return any(marker in text for marker in error_markers)
 ```
 
 #### 学期情報の抽出
@@ -255,15 +176,13 @@ async def fetch_syllabus(client: httpx.AsyncClient, pkey: str) -> str | None:
         raise  # tenacityがリトライ
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
-            return None  # pKeyが存在しない → スキップ
+            return None
         raise
 ```
 
-エラー種別と対処方針：
-
 | エラー | 対処 |
 |--------|------|
-| 404 / エラーページ | スキップ（存在しないpKey） |
+| 404 | スキップ |
 | タイムアウト | 最大3回リトライ（指数バックオフ） |
 | 5xx | 最大3回リトライ後、警告ログ出力してスキップ |
 | パースエラー | raw_htmlを保存してスキップ、後続処理は継続 |
@@ -272,8 +191,6 @@ async def fetch_syllabus(client: httpx.AsyncClient, pkey: str) -> str | None:
 ### レート制限対策
 
 ```python
-import asyncio
-
 class RateLimitedCrawler:
     def __init__(self, requests_per_second: float = 1.0):
         self.interval = 1.0 / requests_per_second
@@ -287,8 +204,6 @@ class RateLimitedCrawler:
         self._last_request_time = asyncio.get_event_loop().time()
 ```
 
-設定値：
-
 | 項目 | 値 |
 |------|-----|
 | リクエスト間隔 | 1秒以上 |
@@ -296,13 +211,12 @@ class RateLimitedCrawler:
 | User-Agent | `WasedaSyllabusMCP/1.0 (research purpose)` |
 | タイムアウト | 30秒 |
 
-### チェックポイントと再開
+35,000件 × 1秒 ≒ 約10時間。年1回の定期実行を想定。
 
-大量のpKeyを処理する際、中断時に再開できるようチェックポイントを保存する：
+### チェックポイントと再開
 
 ```python
 class CrawlState:
-    """クロール進捗の管理"""
     def __init__(self, checkpoint_path: Path):
         self.checkpoint_path = checkpoint_path
         self.completed: set[str] = self._load()
@@ -353,7 +267,6 @@ class SyllabusRecord(BaseModel):
 ### データモデル
 
 ```python
-# DB スキーマ（SQLAlchemy）
 class Syllabus(Base):
     __tablename__ = "syllabuses"
 
@@ -367,7 +280,7 @@ class Syllabus(Base):
     description = Column(Text)
     objectives = Column(Text)
     evaluation = Column(Text)
-    raw_html = Column(Text)           # 生HTML（再パース用）
+    raw_html = Column(Text)
     crawled_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, onupdate=func.now())
 ```
@@ -385,18 +298,15 @@ class Syllabus(Base):
 
 | 案 | 採用しなかった理由 |
 |---|---|
-| Scrapy | asyncio との統合が複雑、Playwright との連携が難しい |
-| Playwright のみで全取得 | httpxより低速・高コスト、詳細ページは静的HTMLで十分 |
+| pKey生成方式（基幹理工） | 存在しないpKeyへの無駄なリクエストが発生、学部別コード管理が必要 |
+| 学部コード（`p_gakubu`）でループ | `nendo`だけで全件取れるため不要 |
+| Scrapy | asyncioとの統合が複雑、Playwrightとの連携が難しい |
 | requests（同期） | 並列処理が困難、asyncioとの統合不可 |
 | Selenium | Playwrightより低速・設定が煩雑 |
 
 ## 未解決の質問
 
-- [ ] 他学部の学部コード一覧（`p_gakubu` の全パラメータ値）
 - [ ] JAA103.php のページネーション構造（ページ送りのDOM操作方法）
-- [ ] JAA103.php の検索POSTパラメータ（キーワード検索を有効化できるか）
-- [ ] pKey後半部分（位置19-26）の参照ルールの完全な仕様
-- [ ] 学科コード `05` の意味（物理系？）
 - [ ] robots.txt の内容・スクレイピング可否（要確認）
 - [ ] クローラー実行スケジューリング方式（cron vs GitHub Actions）
 
@@ -406,13 +316,12 @@ class Syllabus(Base):
 - robots.txt を必ず確認し、Disallow 指定がある場合は従う
 - 適切な User-Agent を設定してボットであることを明示する
 - 1リクエスト/秒のレート制限でサーバー負荷を最小化する
-- クローリング目的・連絡先を User-Agent または別途告知する
 
 ## テスト戦略
 
-- **Unit テスト**: pKey生成関数、HTMLパーサー（モックHTMLを使用）
+- **Unit テスト**: HTMLパーサー（モックHTMLを使用）
 - **Integration テスト**: httpxのモックサーバーを立ててクローラー全体をテスト
-- **Playwright テスト**: テスト用の静的HTMLファイルをローカルサーバーで配信してテスト
+- **Playwright テスト**: 静的HTMLファイルをローカルサーバーで配信してテスト
 - **バリデーションテスト**: 不正なpKey・欠損フィールドに対するPydanticモデルの動作確認
 
 ## 参考資料


### PR DESCRIPTION
## 概要

早稲田大学シラバスサイトからデータを収集するクローラーの設計ドキュメントを追加する。
基幹理工学部向けのpKey生成方式と他学部向けの検索API方式の2戦略を定義した。

## Issue

Closes #3

## 変更内容

- `docs/design/crawler-design.md` を新規作成
- pKey構造（28文字固定）の詳細仕様と学科コード・科目区分コード一覧を記載
- 基幹理工学部向けpKey総当たり生成戦略を定義
- 他学部向けPlaywright検索API方式を定義
- Playwright / httpxの使い分け基準を整理
- HTMLパース戦略（エラーページ判定・学期情報抽出）を記載
- エラーハンドリング・リトライロジック（tenacity）を設計
- レート制限対策（1リクエスト/秒）を定義
- Pydanticによるデータ検証・クリーニング方針を記載
- チェックポイント機能（中断・再開）の設計を記載

## 実装の詳細

提供された調査まとめに基づき以下を設計に反映した：

- pKey後半部（位置17-28）の「参照先」概念：複数学科で同一内容を開講する場合に後半が異なる値を持つ
- 検索結果ページのリンクはJS動的生成のため、Playwrightが必須
- `nendo` パラメータは効くが `p_nendo` / `p_keyw` は効かない（GETでは無効）

## 今後の課題

- [ ] 他学部の `p_gakubu` 全パラメータ値の調査
- [ ] JAA103.php ページネーション構造の調査
- [ ] robots.txt の確認・スクレイピング可否の検討
- [ ] 学科コード `05` の特定

## レビュー観点

- pKey生成ロジック（特にクラスコードの上限・連番の上限）が適切か確認してください
- レート制限（1リクエスト/秒）がサイトへの配慮として十分か確認してください
- エラー種別と対処方針に漏れがないか確認してください