### PR TITLE
feat(backend): linter・formatter設定とGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -1,0 +1,60 @@
+name: Backend Lint & Type Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/backend/**"
+      - ".github/workflows/backend-lint.yml"
+  pull_request:
+    paths:
+      - "apps/backend/**"
+      - ".github/workflows/backend-lint.yml"
+
+defaults:
+  run:
+    working-directory: apps/backend
+
+jobs:
+  lint:
+    name: Ruff Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-packages
+
+      - name: Run ruff lint
+        run: uv run ruff check .
+
+      - name: Run ruff format check
+        run: uv run ruff format --check .
+
+  typecheck:
+    name: Mypy Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-packages
+
+      - name: Run mypy
+        run: uv run mypy packages/

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -11,4 +11,35 @@ dev-dependencies = [
     "pytest-asyncio>=0.23",
     "ruff>=0.4",
     "mypy>=1.10",
+    "types-beautifulsoup4>=4.12",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (ruff format handles this)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["waseda_libs", "waseda_api", "waseda_mcp"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+ignore_missing_imports = true
+exclude = ["packages/libs/src/db/gen/"]


### PR DESCRIPTION
## 概要

バックエンドの ruff（lint・format）と mypy（型チェック）の設定を整備し、PR・push 時に自動実行される GitHub Actions ワークフローを追加する。

## Issue

Closes #26

## 変更内容

- `apps/backend/pyproject.toml` に `[tool.ruff]`・`[tool.ruff.lint]`・`[tool.ruff.format]`・`[tool.mypy]` セクションを追加
- ruff: `target-version = py312`、`line-length = 100`、E/W/F/I/B/UP ルールを有効化、isort の first-party パッケージを設定
- mypy: `strict = true`、`ignore_missing_imports = true`、自動生成コード `packages/libs/src/db/gen/` を除外
- `.github/workflows/backend-lint.yml` を新規作成（`lint` ジョブ: ruff check + format check、`typecheck` ジョブ: mypy）
- `apps/backend/**` または workflow ファイル自体が変更された push/PR でトリガー

## レビュー観点

- ruff の選択ルール（E/W/F/I/B/UP）が適切か確認してください
- mypy の `strict` モードで既存コードに過剰なエラーが出ないか確認してください